### PR TITLE
First pass at syncing functionality.

### DIFF
--- a/server.py
+++ b/server.py
@@ -107,6 +107,7 @@ class AMCPServer(liblo.Server):
                 'mist': self.water.mist,
                 'spare': self.water.spare,
                 'make_it_rain': self.water.make_it_rain,
+                'all_rain_off': self.water.all_rain_off
             }
         }
 
@@ -247,6 +248,11 @@ class Water():
         time.sleep(5000)
         self.rain(False)
         pass
+
+    def all_rain_off(self, press):
+        # TODO(ed): Turn off all the rain
+        if press:
+            logger.info('system="%s", action="all_rain_off"', self.system)
 
     def all_the_rain(self):
         pass


### PR DESCRIPTION
If you turn on TouchOSC's ping option, every 60seconds you'll send a ping to the server
in turn the server will run sync on all of the systems/pages and broadcast the settings
to the subnet. I wish I could find out a way to send to just the client on ping.

Additionally, when you activate a page the server will sync the state of the page. Again
broadcasting to everyone since I can't get the ip.

The ping sync accounts for when you're staying on a page and other people are changing it,
while the page activation sync makes sure you have the most up to date info when you load
a page.

Best way to test this is to go into the Water page, turn on some toggles, then kill the
server and switch to another page. Start the server back up (so all toggles will be 0)
and then switch to the Water page. You should see a flash of the red receive icon, and
the toggles will reset. Hurrah.
